### PR TITLE
remove versionCode reference

### DIFF
--- a/growthbeat/src/main/java/com/growthbeat/utils/AppUtils.java
+++ b/growthbeat/src/main/java/com/growthbeat/utils/AppUtils.java
@@ -5,6 +5,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 
+import androidx.core.content.pm.PackageInfoCompat;
+
 public final class AppUtils {
 
     public static String getaAppVersion(Context context) {
@@ -22,7 +24,8 @@ public final class AppUtils {
 
         try {
             PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-            return String.valueOf(packageInfo.versionCode);
+            long longVersionCode = PackageInfoCompat.getLongVersionCode(packageInfo);
+            return String.valueOf((int) longVersionCode);
         } catch (NameNotFoundException e) {
             return null;
         }


### PR DESCRIPTION
`PackageInfo.versionCode` field is deprecated in API level 28.
see https://developer.android.com/reference/android/content/pm/PackageInfo#versionCode

Change to use `androidx.core.content.pm.PackageInfoCompat.getLongVersionCode()`.